### PR TITLE
Fixed overwriting of dapp-url

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -73,7 +73,7 @@ function getCurrentPackageData() {
         var json = JSON.parse(fs.readFileSync(process.cwd() + '/package.json', 'utf8'));
         obj["name"] = json.name;
         obj["whisper-identity"] = "dapp-" + fromAscii(json.name);
-        obj["dapp-url"] = "http://localhost:" + (cli.dappPort || defaultDAppPort);
+        obj["dapp-url"] = json["dapp-url"];
     }
     return obj;
 }

--- a/cli.js
+++ b/cli.js
@@ -73,10 +73,12 @@ function getCurrentPackageData() {
         var json = JSON.parse(fs.readFileSync(process.cwd() + '/package.json', 'utf8'));
         obj["name"] = json.name;
         obj["whisper-identity"] = "dapp-" + fromAscii(json.name);
-		if(json["dapp-url"])
-			obj["dapp-url"] = json["dapp-url"];
-		if(json["bot-url"])
-			obj["bot-url"] = json["bot-url"];
+	    if(json["dapp-url"])
+	    	obj["dapp-url"] = json["dapp-url"];
+	    if(json["bot-url"])
+	    	obj["bot-url"] = json["bot-url"];
+	    if(!json["dapp-url"] && !json["bot-url"])
+		throw "Neither 'dapp-url' nor 'bot-url' where provided in package.json"
     }
     return obj;
 }

--- a/cli.js
+++ b/cli.js
@@ -73,11 +73,13 @@ function getCurrentPackageData() {
         var json = JSON.parse(fs.readFileSync(process.cwd() + '/package.json', 'utf8'));
         obj["name"] = json.name;
         obj["whisper-identity"] = "dapp-" + fromAscii(json.name);
-        obj["dapp-url"] = json["dapp-url"];
+		if(json["dapp-url"])
+			obj["dapp-url"] = json["dapp-url"];
+		if(json["bot-url"])
+			obj["bot-url"] = json["bot-url"];
     }
     return obj;
 }
-
 function getPackageData(contact) {
     var contactData;
     if (!contact) {

--- a/cli.js
+++ b/cli.js
@@ -78,7 +78,7 @@ function getCurrentPackageData() {
 	    if(json["bot-url"])
 	    	obj["bot-url"] = json["bot-url"];
 	    if(!json["dapp-url"] && !json["bot-url"])
-		throw "Neither 'dapp-url' nor 'bot-url' where provided in package.json"
+		console.error(chalk.red("Neither 'dapp-url' nor 'bot-url' where provided in package.json"));
     }
     return obj;
 }


### PR DESCRIPTION
When providing a package.json the 'getPackageData' functions now takes the url defined under 'dapp-url'
This resolves and close status-im/status-dev-cli#4