### PR TITLE
Add photoPath support for the start script in truffle-box-status

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -69,11 +69,11 @@ function getCurrentPackageData() {
     var obj = {};
     if (fs.existsSync(process.cwd() + '/package.json')) {
         var json = JSON.parse(fs.readFileSync(process.cwd() + '/package.json', 'utf8'));
-        obj["name"] = json.name;
-        obj["whisper-identity"] = "dapp-" + fromAscii(json.name);
-        obj["dapp-url"] = json["dapp-url"] || cli.dappUrl;
-        obj["bot-url"] = json["bot-url"] || cli.botUrl;
-        obj["photo-path"] = json["photo-path"] || cli.photoPath;
+        obj["name"] = cli.name || json.name;
+        obj["whisper-identity"] = cli.whisperIdentity || "dapp-" + fromAscii(json.name) ;
+        obj["dapp-url"] = cli.dappUrl || json["dapp-url"];
+        obj["bot-url"] = cli.botUrl || json["bot-url"];
+        obj["photo-path"] = cli.photoPath || json["photo-path"];
     }
     return obj;
 }
@@ -312,6 +312,7 @@ cli.on("*", function(command) {
 
 cli.version(pkgJson.version)
     .option("--ip [ip]", "IP address of your device")
+    .option("--name [name]", "Name overrides package.json seeing as spaces and caps aren't available there")
     .option("--dappUrl [url]", "Custom DApp URL (overrides the one from the package.json)")
     .option("--botUrl [url]", "Custom bot URL (overrides the one from the package.json)")
     .option("--photoPath [url]", "Custom photo for DApp (overrides the one from the package.json)")

--- a/cli.js
+++ b/cli.js
@@ -315,5 +315,6 @@ cli.version(pkgJson.version)
     .option("--name [name]", "Name overrides package.json seeing as spaces and caps aren't available there")
     .option("--dappUrl [url]", "Custom DApp URL (overrides the one from the package.json)")
     .option("--botUrl [url]", "Custom bot URL (overrides the one from the package.json)")
+    .option("--whisperIdentity [id]", "Custom Whisper Identity (overrides the one from the package.json")
     .option("--photoPath [url]", "Custom photo for DApp (overrides the one from the package.json)")
     .parse(process.argv);

--- a/cli.js
+++ b/cli.js
@@ -73,6 +73,7 @@ function getCurrentPackageData() {
         obj["whisper-identity"] = "dapp-" + fromAscii(json.name);
         obj["dapp-url"] = json["dapp-url"] || cli.dappUrl;
         obj["bot-url"] = json["bot-url"] || cli.botUrl;
+        obj["photo-path"] = json["photo-path"] || cli.photoPath;
     }
     return obj;
 }
@@ -313,4 +314,5 @@ cli.version(pkgJson.version)
     .option("--ip [ip]", "IP address of your device")
     .option("--dappUrl [url]", "Custom DApp URL (overrides the one from the package.json)")
     .option("--botUrl [url]", "Custom bot URL (overrides the one from the package.json)")
+    .option("--photoPath [url]", "Custom photo for DApp (overrides the one from the package.json)")
     .parse(process.argv);


### PR DESCRIPTION
I want to be able to add a `--photoPath` variable to the `start` script in our Truffle Box easily and in the same way as dappUrl and botUrl as it is currently set up.